### PR TITLE
Bugfix, ttl was 0

### DIFF
--- a/src/Session/SessionHandler.php
+++ b/src/Session/SessionHandler.php
@@ -51,7 +51,7 @@ class SessionHandler implements \SessionHandlerInterface
     {
         $this->cache = $cache;
 
-        $this->ttl    = isset($options['cookie_lifetime']) ? (int) $options['cookie_lifetime'] : 86400;
+        $this->ttl    = isset($options['ttl']) ? (int) $options['ttl'] : 86400;
         $this->prefix = isset($options['prefix']) ? $options['prefix'] : 'sf2ses_';
     }
 


### PR DESCRIPTION
This closes #2. 

Please review if this is correct. Why do we have `cookie_lifetime` here?
