### PR TITLE
Remove the dependency on the DoctrineBridge

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,16 +26,17 @@
     "require":      {
         "php":                         "^5.5|^7",
         "symfony/framework-bundle":    "^2.6|^3.0",
-        "cache/psr-6-doctrine-bridge": "^0.1",
         "cache/taggable-cache":        "^0.1",
         "psr/cache-implementation":    "~1.0"
     },
     "require-dev":  {
         "phpunit/phpunit":        "^5.1|^4.0",
+        "cache/psr-6-doctrine-bridge": "^0.1",
         "cache/doctrine-adapter": "^0.1"
     },
     "suggest":      {
-        "cache/doctrine-adapter-bundle": "A bundle to register PSR-6 compliant services based on Doctrine cache"
+        "cache/doctrine-adapter-bundle": "A bundle to register PSR-6 compliant services based on Doctrine cache",
+        "cache/psr-6-doctrine-bridge": "To be able to use Doctrine query, result and metadata cache."
     },
     "autoload":     {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -30,9 +30,9 @@
         "psr/cache-implementation":    "~1.0"
     },
     "require-dev":  {
-        "phpunit/phpunit":        "^5.1|^4.0",
-        "cache/psr-6-doctrine-bridge": "^0.1",
-        "cache/doctrine-adapter": "^0.1"
+        "phpunit/phpunit":             "^5.1|^4.0",
+        "cache/psr-6-doctrine-bridge": "^2.0",
+        "cache/doctrine-adapter":      "^0.1"
     },
     "suggest":      {
         "cache/doctrine-adapter-bundle": "A bundle to register PSR-6 compliant services based on Doctrine cache",

--- a/src/DependencyInjection/Compiler/DoctrineSupportCompilerPass.php
+++ b/src/DependencyInjection/Compiler/DoctrineSupportCompilerPass.php
@@ -41,6 +41,12 @@ class DoctrineSupportCompilerPass extends BaseCompilerPass
             );
         }
 
+        if (!class_exists('Cache\Bridge\DoctrineCacheBridge')) {
+            throw new \Exception(
+                'You need the DoctrineBridge to be able to cache queries, results and metadata. Please run "composer.phar require cache/psr-6-doctrine-bridge" to install the missing dependency.'
+            );
+        }
+
         $this->enableDoctrineSupport($this->container->getParameter('cache.doctrine'));
     }
 

--- a/src/DependencyInjection/Compiler/DoctrineSupportCompilerPass.php
+++ b/src/DependencyInjection/Compiler/DoctrineSupportCompilerPass.php
@@ -43,7 +43,7 @@ class DoctrineSupportCompilerPass extends BaseCompilerPass
 
         if (!class_exists('Cache\Bridge\DoctrineCacheBridge')) {
             throw new \Exception(
-                'You need the DoctrineBridge to be able to cache queries, results and metadata. Please run "composer.phar require cache/psr-6-doctrine-bridge" to install the missing dependency.'
+                'You need the DoctrineBridge to be able to cache queries, results and metadata. Please run "composer require cache/psr-6-doctrine-bridge" to install the missing dependency.'
             );
         }
 


### PR DESCRIPTION
This package depends on the DoctrineBridge which depends on DoctrineCache. This means that if a user wants to install this bundle to use it with the session cache only, we install DoctrineCache which is not needed. 

This PR forces the user to opt-in to use the doctrine cache. 
