### PR TITLE
Improved the cache:flush

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,16 @@
 language: php
+sudo: false
+
 php:
-  - "7.0"
-  - "5.6"
-  - "5.5"
+  - 7.0
+  - 5.6
+  - 5.5
+  - hhvm
 
 env:
+  global:
+    - COMPOSER_COMMAND="composer install --prefer-dist"
+  matrix:
   - SYMFONY_VERSION=2.6.*
   - SYMFONY_VERSION=2.7.*
   - SYMFONY_VERSION=2.8.*
@@ -12,17 +18,20 @@ env:
 
 matrix:
   fast_finish: true
-
-sudo: false
+  include:
+    - php: 5.5
+      env: COMPOSER_COMMAND="composer update --prefer-lowest --prefer-stable" && SYMFONY_VERSION=2.7.*
 
 cache:
     directories:
         - $HOME/.composer/cache
 
-before_script:
+install_script:
     - composer self-update
+
+install:
     - composer require symfony/symfony:${SYMFONY_VERSION} --no-update
-    - composer install --dev --prefer-dist --no-interaction
+    - travis_retry ${COMPOSER_COMMAND} --no-interaction
 
 script:
     - php vendor/bin/phpunit

--- a/composer.json
+++ b/composer.json
@@ -26,13 +26,12 @@
     "require":      {
         "php":                         "^5.5|^7",
         "symfony/framework-bundle":    "^2.6|^3.0",
-        "cache/taggable-cache":        "^0.1",
-        "psr/cache-implementation":    "~1.0"
+        "cache/taggable-cache":        "^0.1|^0.2"
     },
     "require-dev":  {
         "phpunit/phpunit":             "^5.1|^4.0",
         "cache/psr-6-doctrine-bridge": "^2.0",
-        "cache/doctrine-adapter":      "^0.1"
+        "cache/doctrine-adapter":      "^0.3"
     },
     "suggest":      {
         "cache/doctrine-adapter-bundle": "A bundle to register PSR-6 compliant services based on Doctrine cache",

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
     "require":      {
         "php":                         "^5.5|^7",
         "symfony/framework-bundle":    "^2.6|^3.0",
-        "cache/taggable-cache":        "^0.1|^0.2"
+        "cache/taggable-cache":        "^0.2"
     },
     "require-dev":  {
         "phpunit/phpunit":             "^5.1|^4.0",

--- a/src/Cache/FixedTaggingCachePool.php
+++ b/src/Cache/FixedTaggingCachePool.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of php-cache\cache-bundle package.
  *
- * (c) 2015-2015 Aaron Scherer <aequasi@gmail.com>
+ * (c) 2015-2015 Aaron Scherer <aequasi@gmail.com>, Tobias Nyholm <tobias.nyholm@gmail.com>
  *
  * This source file is subject to the MIT license that is bundled
  * with this source code in the file LICENSE.

--- a/src/Cache/LoggingCachePool.php
+++ b/src/Cache/LoggingCachePool.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of php-cache\cache-bundle package.
  *
- * (c) 2015-2015 Aaron Scherer <aequasi@gmail.com>
+ * (c) 2015-2015 Aaron Scherer <aequasi@gmail.com>, Tobias Nyholm <tobias.nyholm@gmail.com>
  *
  * This source file is subject to the MIT license that is bundled
  * with this source code in the file LICENSE.

--- a/src/CacheBundle.php
+++ b/src/CacheBundle.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of php-cache\cache-bundle package.
  *
- * (c) 2015-2015 Aaron Scherer <aequasi@gmail.com>
+ * (c) 2015-2015 Aaron Scherer <aequasi@gmail.com>, Tobias Nyholm <tobias.nyholm@gmail.com>
  *
  * This source file is subject to the MIT license that is bundled
  * with this source code in the file LICENSE.

--- a/src/Command/CacheFlushCommand.php
+++ b/src/Command/CacheFlushCommand.php
@@ -13,9 +13,11 @@ namespace Cache\CacheBundle\Command;
 
 use Cache\Taggable\TaggablePoolInterface;
 use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Question\ConfirmationQuestion;
 
 /**
  * Class CacheFlushCommand.
@@ -24,6 +26,8 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 class CacheFlushCommand extends ContainerAwareCommand
 {
+    const validTypes = ['all', 'session', 'router', 'doctrine', 'symfony', 'provider'];
+
     /**
      * {@inheritdoc}
      */
@@ -31,7 +35,20 @@ class CacheFlushCommand extends ContainerAwareCommand
     {
         $this->setName('cache:flush');
         $this->setDescription('Flushes the given cache');
-        $this->addArgument('type', InputArgument::REQUIRED, 'Which type of cache do you want to clear?');
+        $this->addArgument('type', InputArgument::OPTIONAL, sprintf('Which type of cache do you want to clear? Valid types are: %s', implode(', ', self::validTypes)));
+        $this->addArgument('service', InputArgument::OPTIONAL, 'If using type "provider" you must give a service id for the cache you want to clear.');
+        $this->setHelp(<<<EOD
+
+Types and their description
+all                       Clear all types of caches
+doctrine                  Clear doctrine cache for query, result and metadata
+privider cache.acme       Clear all the cache for the provider with service id "cache.acme"
+router                    Clear router cache
+session                   Clear session cache. All your logged in users will be logged out.
+symfony                   Clear Symfony cache. This is the same as cache:clear
+
+EOD
+    );
     }
 
     /**
@@ -39,60 +56,149 @@ class CacheFlushCommand extends ContainerAwareCommand
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $validTypes = ['session', 'router', 'doctrine'];
-        $type       = $input->getArgument('type');
+        if (false ===$type = $this->verifyArguments($input, $output)) {
+            return 0;
+        }
+
+        $builtInTypes = ['session', 'router', 'doctrine'];
+        if (in_array($type, $builtInTypes)) {
+            return $this->clearCacheForBuiltInType($type)?0:1;
+        }
+
+        if ($type === 'symfony') {
+            return $this->clearSymfonyCache($output)?0:1;
+        }
+
+        if ($type === 'provider') {
+            return $this->clearCacheForProvider($input->getArgument('service'))?0:1;
+        }
+
         if ($type === 'all') {
-            foreach ($validTypes as $type) {
-                $this->clearCacheForType($type);
+            $result = true;
+            foreach ($builtInTypes as $builtInType) {
+                $result = $result && $this->clearCacheForBuiltInType($builtInType);
             }
+            $result = $result && $this->clearSymfonyCache($output);
 
-            return;
+            return $result?0:1;
         }
-
-        // If not "all", verify that $type is valid
-        if (!in_array($type, $validTypes)) {
-            $output->writeln(sprintf('Type "%s" does not exist. Valid type are: %s', $type, implode(',', $validTypes)));
-
-            return;
-        }
-
-        $this->clearCacheForType($type);
     }
 
     /**
      * Clear the cache for a type.
      *
      * @param string $type
+     *
+     * @return bool
      */
-    private function clearCacheForType($type)
+    private function clearCacheForBuiltInType($type)
     {
         if (!$this->getContainer()->hasParameter(sprintf('cache.%s', $type))) {
-            return;
+            return true;
         }
 
         $config = $this->getContainer()->getParameter(sprintf('cache.%s', $type));
 
         if ($type === 'doctrine') {
-            $this->doClearCache($type, $config['metadata']['service_id']);
-            $this->doClearCache($type, $config['result']['service_id']);
-            $this->doClearCache($type, $config['query']['service_id']);
+            $result = true;
+            $result = $result && $this->clearTypedCacheFromService($type, $config['metadata']['service_id']);
+            $result = $result && $this->clearTypedCacheFromService($type, $config['result']['service_id']);
+            $result = $result && $this->clearTypedCacheFromService($type, $config['query']['service_id']);
+
+            return $result;
         } else {
-            $this->doClearCache($type, $config['service_id']);
+            return $this->clearTypedCacheFromService($type, $config['service_id']);
         }
     }
 
     /**
      * @param string $type
      * @param string $serviceId
+     *
+     * @return bool
      */
-    private function doClearCache($type, $serviceId)
+    private function clearTypedCacheFromService($type, $serviceId)
     {
         /** @type \Psr\Cache\CacheItemPoolInterface $service */
         $service = $this->getContainer()->get($serviceId);
         if ($service instanceof TaggablePoolInterface) {
-            $service->clear([$type]);
+            return $service->clear([$type]);
         } else {
-            $service->clear();
+            return $service->clear();
         }
+    }
+
+    /**
+     *
+     * @param InputInterface $input
+     * @param OutputInterface $output
+     *
+     * @return string|bool type or false if invalid arguements
+     */
+    protected function verifyArguments(InputInterface $input, OutputInterface $output)
+    {
+        $type = $input->getArgument('type');
+        if ($type === null) {
+            // ask a question and default $type='all'
+            $helper = $this->getHelper('question');
+            $question = new ConfirmationQuestion('Do you want to clear all cache? [N] ', false);
+
+            if (!$helper->ask($input, $output, $question)) {
+                return false;
+            }
+
+            $type = 'all';
+        }
+
+        if (!in_array($type, self::validTypes)) {
+            $output->writeln(
+                sprintf(
+                    '<error>Type "%s" does not exist. Valid type are: %s.</error>',
+                    $type,
+                    implode(', ', self::validTypes)
+                )
+            );
+
+            return false;
+        }
+
+        if ($type === 'provider' && !$input->hasArgument('service')) {
+            $output->writeln(
+                '<error>When using type "provider" you must specify a service id for that provider.</error>'
+            );
+            $output->writeln('<error>Usage: php app/console cache:flush provider cache.provider.acme</error>');
+
+            return false;
+        }
+
+        return $type;
+    }
+
+    /**
+     * @param string $serviceId
+     *
+     * @return bool
+     */
+    protected function clearCacheForProvider($serviceId)
+    {
+        /** @type \Psr\Cache\CacheItemPoolInterface $service */
+        $service = $this->getContainer()->get($serviceId);
+
+        return $service->clear();
+    }
+
+    /**
+     * @param OutputInterface $output
+     *
+     * @return bool
+     */
+    protected function clearSymfonyCache(OutputInterface $output)
+    {
+        $command = $this->getApplication()->find('cache:clear');
+        $arguments = array(
+            'command' => 'cache:clear',
+        );
+
+        return $command->run(new ArrayInput($arguments), $output) === 0;
     }
 }

--- a/src/Command/CacheFlushCommand.php
+++ b/src/Command/CacheFlushCommand.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of php-cache\cache-bundle package.
  *
- * (c) 2015-2015 Aaron Scherer <aequasi@gmail.com>
+ * (c) 2015-2015 Aaron Scherer <aequasi@gmail.com>, Tobias Nyholm <tobias.nyholm@gmail.com>
  *
  * This source file is subject to the MIT license that is bundled
  * with this source code in the file LICENSE.
@@ -56,21 +56,21 @@ EOD
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        if (false ===$type = $this->verifyArguments($input, $output)) {
+        if (false === $type = $this->verifyArguments($input, $output)) {
             return 0;
         }
 
         $builtInTypes = ['session', 'router', 'doctrine'];
         if (in_array($type, $builtInTypes)) {
-            return $this->clearCacheForBuiltInType($type)?0:1;
+            return $this->clearCacheForBuiltInType($type) ? 0 : 1;
         }
 
         if ($type === 'symfony') {
-            return $this->clearSymfonyCache($output)?0:1;
+            return $this->clearSymfonyCache($output) ? 0 : 1;
         }
 
         if ($type === 'provider') {
-            return $this->clearCacheForProvider($input->getArgument('service'))?0:1;
+            return $this->clearCacheForProvider($input->getArgument('service')) ? 0 : 1;
         }
 
         if ($type === 'all') {
@@ -80,7 +80,7 @@ EOD
             }
             $result = $result && $this->clearSymfonyCache($output);
 
-            return $result?0:1;
+            return $result ? 0 : 1;
         }
     }
 
@@ -129,8 +129,7 @@ EOD
     }
 
     /**
-     *
-     * @param InputInterface $input
+     * @param InputInterface  $input
      * @param OutputInterface $output
      *
      * @return string|bool type or false if invalid arguements
@@ -140,7 +139,7 @@ EOD
         $type = $input->getArgument('type');
         if ($type === null) {
             // ask a question and default $type='all'
-            $helper = $this->getHelper('question');
+            $helper   = $this->getHelper('question');
             $question = new ConfirmationQuestion('Do you want to clear all cache? [N] ', false);
 
             if (!$helper->ask($input, $output, $question)) {
@@ -194,10 +193,10 @@ EOD
      */
     protected function clearSymfonyCache(OutputInterface $output)
     {
-        $command = $this->getApplication()->find('cache:clear');
-        $arguments = array(
+        $command   = $this->getApplication()->find('cache:clear');
+        $arguments = [
             'command' => 'cache:clear',
-        );
+        ];
 
         return $command->run(new ArrayInput($arguments), $output) === 0;
     }

--- a/src/DataCollector/CacheDataCollector.php
+++ b/src/DataCollector/CacheDataCollector.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of php-cache\cache-bundle package.
  *
- * (c) 2015-2015 Aaron Scherer <aequasi@gmail.com>
+ * (c) 2015-2015 Aaron Scherer <aequasi@gmail.com>, Tobias Nyholm <tobias.nyholm@gmail.com>
  *
  * This source file is subject to the MIT license that is bundled
  * with this source code in the file LICENSE.

--- a/src/DependencyInjection/CacheExtension.php
+++ b/src/DependencyInjection/CacheExtension.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of php-cache\cache-bundle package.
  *
- * (c) 2015-2015 Aaron Scherer <aequasi@gmail.com>
+ * (c) 2015-2015 Aaron Scherer <aequasi@gmail.com>, Tobias Nyholm <tobias.nyholm@gmail.com>
  *
  * This source file is subject to the MIT license that is bundled
  * with this source code in the file LICENSE.

--- a/src/DependencyInjection/Compiler/BaseCompilerPass.php
+++ b/src/DependencyInjection/Compiler/BaseCompilerPass.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of php-cache\cache-bundle package.
  *
- * (c) 2015-2015 Aaron Scherer <aequasi@gmail.com>
+ * (c) 2015-2015 Aaron Scherer <aequasi@gmail.com>, Tobias Nyholm <tobias.nyholm@gmail.com>
  *
  * This source file is subject to the MIT license that is bundled
  * with this source code in the file LICENSE.

--- a/src/DependencyInjection/Compiler/DataCollectorCompilerPass.php
+++ b/src/DependencyInjection/Compiler/DataCollectorCompilerPass.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of php-cache\cache-bundle package.
  *
- * (c) 2015-2015 Aaron Scherer <aequasi@gmail.com>
+ * (c) 2015-2015 Aaron Scherer <aequasi@gmail.com>, Tobias Nyholm <tobias.nyholm@gmail.com>
  *
  * This source file is subject to the MIT license that is bundled
  * with this source code in the file LICENSE.

--- a/src/DependencyInjection/Compiler/DoctrineSupportCompilerPass.php
+++ b/src/DependencyInjection/Compiler/DoctrineSupportCompilerPass.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of php-cache\cache-bundle package.
  *
- * (c) 2015-2015 Aaron Scherer <aequasi@gmail.com>
+ * (c) 2015-2015 Aaron Scherer <aequasi@gmail.com>, Tobias Nyholm <tobias.nyholm@gmail.com>
  *
  * This source file is subject to the MIT license that is bundled
  * with this source code in the file LICENSE.

--- a/src/DependencyInjection/Compiler/SessionSupportCompilerPass.php
+++ b/src/DependencyInjection/Compiler/SessionSupportCompilerPass.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of php-cache\cache-bundle package.
  *
- * (c) 2015-2015 Aaron Scherer <aequasi@gmail.com>
+ * (c) 2015-2015 Aaron Scherer <aequasi@gmail.com>, Tobias Nyholm <tobias.nyholm@gmail.com>
  *
  * This source file is subject to the MIT license that is bundled
  * with this source code in the file LICENSE.

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of php-cache\cache-bundle package.
  *
- * (c) 2015-2015 Aaron Scherer <aequasi@gmail.com>
+ * (c) 2015-2015 Aaron Scherer <aequasi@gmail.com>, Tobias Nyholm <tobias.nyholm@gmail.com>
  *
  * This source file is subject to the MIT license that is bundled
  * with this source code in the file LICENSE.

--- a/src/Routing/CachingRouter.php
+++ b/src/Routing/CachingRouter.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of php-cache\cache-bundle package.
  *
- * (c) 2015-2015 Aaron Scherer <aequasi@gmail.com>
+ * (c) 2015-2015 Aaron Scherer <aequasi@gmail.com>, Tobias Nyholm <tobias.nyholm@gmail.com>
  *
  * This source file is subject to the MIT license that is bundled
  * with this source code in the file LICENSE.

--- a/src/Session/SessionHandler.php
+++ b/src/Session/SessionHandler.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of php-cache\cache-bundle package.
  *
- * (c) 2015-2015 Aaron Scherer <aequasi@gmail.com>
+ * (c) 2015-2015 Aaron Scherer <aequasi@gmail.com>, Tobias Nyholm <tobias.nyholm@gmail.com>
  *
  * This source file is subject to the MIT license that is bundled
  * with this source code in the file LICENSE.

--- a/tests/ContainerTest.php
+++ b/tests/ContainerTest.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of php-cache\cache-bundle package.
  *
- * (c) 2015-2015 Aaron Scherer <aequasi@gmail.com>
+ * (c) 2015-2015 Aaron Scherer <aequasi@gmail.com>, Tobias Nyholm <tobias.nyholm@gmail.com>
  *
  * This source file is subject to the MIT license that is bundled
  * with this source code in the file LICENSE.

--- a/tests/DependencyInjection/CacheExtensionTest.php
+++ b/tests/DependencyInjection/CacheExtensionTest.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of php-cache\cache-bundle package.
  *
- * (c) 2015-2015 Aaron Scherer <aequasi@gmail.com>
+ * (c) 2015-2015 Aaron Scherer <aequasi@gmail.com>, Tobias Nyholm <tobias.nyholm@gmail.com>
  *
  * This source file is subject to the MIT license that is bundled
  * with this source code in the file LICENSE.

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of php-cache\cache-bundle package.
  *
- * (c) 2015-2015 Aaron Scherer <aequasi@gmail.com>
+ * (c) 2015-2015 Aaron Scherer <aequasi@gmail.com>, Tobias Nyholm <tobias.nyholm@gmail.com>
  *
  * This source file is subject to the MIT license that is bundled
  * with this source code in the file LICENSE.


### PR DESCRIPTION
You may now use `cache:flush symfony` to flush the Symfony cache. 

I've also updated some dependencies.
