### PR TITLE
Make sure we always dealing with ta tagging cache pool

### DIFF
--- a/src/Cache/RecordingCachePool.php
+++ b/src/Cache/RecordingCachePool.php
@@ -12,6 +12,7 @@
 namespace Cache\CacheBundle\Cache;
 
 use Cache\Taggable\TaggablePoolInterface;
+use Cache\Taggable\TaggablePSR6PoolAdapter;
 use Psr\Cache\CacheItemInterface;
 use Psr\Cache\CacheItemPoolInterface;
 
@@ -37,7 +38,7 @@ class RecordingCachePool implements CacheItemPoolInterface, TaggablePoolInterfac
      */
     public function __construct(CacheItemPoolInterface $cachePool)
     {
-        $this->cachePool = $cachePool;
+        $this->cachePool = TaggablePSR6PoolAdapter::makeTaggable($cachePool);
     }
 
     /**

--- a/src/Factory/DoctrineBridgeFactory.php
+++ b/src/Factory/DoctrineBridgeFactory.php
@@ -13,6 +13,7 @@ namespace Cache\CacheBundle\Factory;
 
 use Cache\Bridge\DoctrineCacheBridge;
 use Cache\CacheBundle\Cache\FixedTaggingCachePool;
+use Cache\Taggable\TaggablePSR6PoolAdapter;
 use Psr\Cache\CacheItemPoolInterface;
 
 /**
@@ -30,7 +31,7 @@ class DoctrineBridgeFactory
     public static function get(CacheItemPoolInterface $pool, $config, array $tags)
     {
         if ($config['use_tagging']) {
-            $pool = new FixedTaggingCachePool($pool, $tags);
+            $pool = new FixedTaggingCachePool(TaggablePSR6PoolAdapter::makeTaggable($pool), $tags);
         }
 
         return new DoctrineCacheBridge($pool);

--- a/src/Factory/SessionHandlerFactory.php
+++ b/src/Factory/SessionHandlerFactory.php
@@ -13,6 +13,7 @@ namespace Cache\CacheBundle\Factory;
 
 use Cache\CacheBundle\Cache\FixedTaggingCachePool;
 use Cache\SessionHandler\Psr6SessionHandler;
+use Cache\Taggable\TaggablePSR6PoolAdapter;
 use Psr\Cache\CacheItemPoolInterface;
 
 /**
@@ -29,7 +30,7 @@ class SessionHandlerFactory
     public static function get(CacheItemPoolInterface $pool, $config)
     {
         if ($config['use_tagging']) {
-            $pool = new FixedTaggingCachePool($pool, ['session']);
+            $pool = new FixedTaggingCachePool(TaggablePSR6PoolAdapter::makeTaggable($pool), ['session']);
         }
 
         return new Psr6SessionHandler($pool, $config);

--- a/src/Factory/ValidationFactory.php
+++ b/src/Factory/ValidationFactory.php
@@ -13,6 +13,7 @@ namespace Cache\CacheBundle\Factory;
 
 use Cache\CacheBundle\Bridge\SymfonyValidatorBridge;
 use Cache\CacheBundle\Cache\FixedTaggingCachePool;
+use Cache\Taggable\TaggablePSR6PoolAdapter;
 use Psr\Cache\CacheItemPoolInterface;
 
 /**
@@ -29,7 +30,7 @@ class ValidationFactory
     public static function get(CacheItemPoolInterface $pool, $config)
     {
         if ($config['use_tagging']) {
-            $pool = new FixedTaggingCachePool($pool, ['validation']);
+            $pool = new FixedTaggingCachePool(TaggablePSR6PoolAdapter::makeTaggable($pool), ['validation']);
         }
 
         return new SymfonyValidatorBridge($pool);


### PR DESCRIPTION
Please review this. Im not too sure this is a good solution. 
The problem occurs when we are using a pool that do not support tagging, say APC. In debug we put the APC pool in the recording pool because we want to use the WebToolbar. The recording pool is always a Taggable pool. That's why we get errors like this: https://github.com/php-cache/issues/issues/50

```
Warning: call_user_func_array() expects parameter 1 to be a valid callback, class 'Cache\Adapter\Apc\ApcCachePool'
```

This solution makes sure we are always dealing with a Taggable pool. 
