### PR TITLE
Update RecordingCachePool.php

### DIFF
--- a/src/Cache/RecordingCachePool.php
+++ b/src/Cache/RecordingCachePool.php
@@ -56,7 +56,7 @@ class RecordingCachePool implements CacheItemPoolInterface, TaggablePoolInterfac
      *
      * @return object
      */
-    private function timeCall($name, array $arguments = null)
+    private function timeCall($name, array $arguments = [])
     {
         $start  = microtime(true);
         $result = call_user_func_array([$this->cachePool, $name], $arguments);


### PR DESCRIPTION
default second argument changed to **empty array** in method timeCall, because calling `call_user_func_array([$this->cachePool, $name], $arguments);` is expecting second argument only Array, not NULL.
