### PR TITLE
Adds an option to disable the data collector

### DIFF
--- a/src/DependencyInjection/CacheExtension.php
+++ b/src/DependencyInjection/CacheExtension.php
@@ -57,7 +57,11 @@ class CacheExtension extends Extension
         $this->registerServices($container, $config);
 
         // Add toolbar and data collector if we are debuging
-        if ($container->getParameter('kernel.debug')) {
+        if (!isset($config['data_collector']['enabled'])) {
+            $config['data_collector']['enabled'] = $container->getParameter('kernel.debug');
+        }
+
+        if ($config['data_collector']['enabled']) {
             $loader->load('data-collector.yml');
         }
 

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -238,7 +238,6 @@ class Configuration implements ConfigurationInterface
         return $node;
     }
 
-
     /**
      * @return ArrayNodeDefinition
      */

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -40,6 +40,7 @@ class Configuration implements ConfigurationInterface
             ->append($this->addSerializerSection())
             ->append($this->addValidationSection())
             ->append($this->addLoggingSection())
+            ->append($this->addDataCollectorSection())
             ->end();
 
         return $treeBuilder;
@@ -232,6 +233,23 @@ class Configuration implements ConfigurationInterface
                 ->end()
                 ->booleanNode('use_tagging')->defaultTrue()->end()
                 ->scalarNode('prefix')->defaultValue('')->end()
+            ->end();
+
+        return $node;
+    }
+
+
+    /**
+     * @return ArrayNodeDefinition
+     */
+    private function addDataCollectorSection()
+    {
+        $tree = new TreeBuilder();
+        $node = $tree->root('data_collector');
+
+        $node
+            ->children()
+                ->booleanNode('enabled')->end()
             ->end();
 
         return $node;


### PR DESCRIPTION
We need a way to disable the data collector as during development our app regularly runs out of memory because of how much data it collects. In our particular case we use a lot of annotations and doctrine is caching those in memcache. We end up running over our memory limit.

We don't get much value from the data collector so the option to disable solves the problem for us.