### PR TITLE
Register CachePools to Clear command to clear all

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
     "require": {
         "php": "^5.6 || ^7.0",
         "symfony/framework-bundle": "^2.7 || ^3.0",
-        "symfony/var-dumper": "^3.3",
+        "symfony/var-dumper": "^2.7 || ^3.0",
         "cache/taggable-cache": "^1.0",
         "cache/session-handler": "^1.0",
         "nyholm/nsa": "^1.1"

--- a/src/Command/CacheFlushCommand.php
+++ b/src/Command/CacheFlushCommand.php
@@ -11,7 +11,6 @@
 
 namespace Cache\CacheBundle\Command;
 
-use Cache\Adapter\Chain\CachePoolChain;
 use Cache\CacheBundle\DataCollector\CacheProxyInterface;
 use Cache\Taggable\TaggablePoolInterface;
 use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
@@ -29,7 +28,7 @@ use Symfony\Component\Console\Question\ConfirmationQuestion;
 class CacheFlushCommand extends ContainerAwareCommand
 {
     /**
-     * @var CacheProxyInterface[]
+     * @type CacheProxyInterface[]
      */
     private $instances = [];
 
@@ -95,11 +94,11 @@ EOD
         if ($type === 'all') {
             $result = true;
             foreach ($builtInTypes as $builtInType) {
-                $output->writeln(" // Clearing cache for built in type <info>'" . $builtInType . '"</info>');
+                $output->writeln(" // Clearing cache for built in type <info>'".$builtInType.'"</info>');
                 $result = $result && $this->clearCacheForBuiltInType($builtInType);
             }
             foreach (array_keys($this->instances) as $instance) {
-                $output->writeln(" // Clearing cache for provider <info>'" . $instance . '"</info>');
+                $output->writeln(" // Clearing cache for provider <info>'".$instance.'"</info>');
                 $result = $result && $this->clearCacheForProvider($instance);
             }
             $result = $result && $this->clearSymfonyCache($output);

--- a/src/Command/CacheFlushCommand.php
+++ b/src/Command/CacheFlushCommand.php
@@ -94,11 +94,11 @@ EOD
         if ($type === 'all') {
             $result = true;
             foreach ($builtInTypes as $builtInType) {
-                $output->writeln(" // Clearing cache for built in type <info>'".$builtInType.'"</info>');
+                $output->writeln(" // Clearing cache for built in type <info>'".$builtInType."'</info>");
                 $result = $result && $this->clearCacheForBuiltInType($builtInType);
             }
             foreach (array_keys($this->instances) as $instance) {
-                $output->writeln(" // Clearing cache for provider <info>'".$instance.'"</info>');
+                $output->writeln(" // Clearing cache for provider <info>'".$instance."'</info>");
                 $result = $result && $this->clearCacheForProvider($instance);
             }
             $result = $result && $this->clearSymfonyCache($output);

--- a/src/Command/CacheFlushCommand.php
+++ b/src/Command/CacheFlushCommand.php
@@ -109,6 +109,7 @@ EOD
      * Clear the cache for a type.
      *
      * @param string $type
+     * @param OutputInterface $output
      *
      * @return bool
      */
@@ -139,6 +140,7 @@ EOD
     /**
      * @param string $type
      * @param string $serviceId
+     * @param OutputInterface $output
      *
      * @return bool
      */
@@ -205,6 +207,7 @@ EOD
 
     /**
      * @param string $serviceId
+     * @param OutputInterface $output
      *
      * @return bool
      */

--- a/src/DependencyInjection/CacheExtension.php
+++ b/src/DependencyInjection/CacheExtension.php
@@ -50,6 +50,8 @@ class CacheExtension extends Extension
             }
         }
 
+        $loader->load('command.yml');
+
         if ($config['doctrine']['enabled']) {
             $this->verifyDoctrineBridgeExists('doctrine');
         }

--- a/src/DependencyInjection/Compiler/DataCollectorCompilerPass.php
+++ b/src/DependencyInjection/Compiler/DataCollectorCompilerPass.php
@@ -33,9 +33,10 @@ class DataCollectorCompilerPass implements CompilerPassInterface
             return;
         }
 
-        $proxyFactory        = $container->get('cache.proxy_factory');
-        $collectorDefinition = $container->getDefinition('cache.data_collector');
-        $serviceIds          = $container->findTaggedServiceIds('cache.provider');
+        $proxyFactory           = $container->get('cache.proxy_factory');
+        $collectorDefinition    = $container->getDefinition('cache.data_collector');
+        $clearCommandDefinition = $container->getDefinition('cache.cache_flush_command');
+        $serviceIds             = $container->findTaggedServiceIds('cache.provider');
 
         foreach (array_keys($serviceIds) as $id) {
 
@@ -60,8 +61,9 @@ class DataCollectorCompilerPass implements CompilerPassInterface
                 $decoratedPool->addMethodCall('__setName', [$id]);
             }
 
-            // Tell the collector to add the new instance
+            // Add provider instances to related services
             $collectorDefinition->addMethodCall('addInstance', [$id, new Reference($id)]);
+            $clearCommandDefinition->addMethodCall('addInstance', [$id, new Reference($id)]);
         }
     }
 }

--- a/src/Resources/config/command.yml
+++ b/src/Resources/config/command.yml
@@ -1,0 +1,5 @@
+services:
+  cache.cache_flush_command:
+    class: Cache\CacheBundle\Command\CacheFlushCommand
+    tags:
+      - { name: console.command }


### PR DESCRIPTION
Right now the `CacheFlushCommand` does not clear all `providers`. By also registering those to the command when building the application, the providers also will get cleared when calling

```
bin/console cache:flush all
```

This MR also outputs info about what cache types have been flushed:

```
[dev@devint www]$ bin/console cache:flush
Do you want to clear all cache? [N] Y
 // Clearing cache for built in type 'annotation"
 // Clearing cache for built in type 'doctrine"
 // Clearing cache for built in type 'serializer"
 // Clearing cache for built in type 'session"
 // Clearing cache for built in type 'router"
 // Clearing cache for built in type 'validation"
 // Clearing cache for provider 'cache.provider.chain"
 // Clearing cache for provider 'cache.provider.file"
 // Clearing cache for provider 'cache.provider.redis"

 // Clearing the cache for the dev environment with debug true

 [OK] Cache for the "dev" environment (debug=true) was successfully cleared.
```