### PR TITLE
Use PHPUnit\Framework\TestCase instead of PHPUnit_Framework_TestCase

### DIFF
--- a/tests/Unit/KeyNormalizerTest.php
+++ b/tests/Unit/KeyNormalizerTest.php
@@ -13,7 +13,7 @@ namespace Cache\CacheBundle\Tests\Unit;
 
 use Cache\CacheBundle\KeyNormalizer;
 
-class KeyNormalizerTest extends \PHPUnit_Framework_TestCase
+class KeyNormalizerTest extends TestCase
 {
     public function testOnlyValid()
     {

--- a/tests/Unit/TestCase.php
+++ b/tests/Unit/TestCase.php
@@ -12,6 +12,7 @@
 namespace Cache\CacheBundle\Tests\Unit;
 
 use Cache\CacheBundle\DependencyInjection\CacheExtension;
+use PHPUnit\Framework\TestCase as BaseTestCase;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
@@ -22,7 +23,7 @@ use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
  *
  * @author Aaron Scherer <aequasi@gmail.com>
  */
-class TestCase extends \PHPUnit_Framework_TestCase
+class TestCase extends BaseTestCase
 {
     /**
      * @param ContainerBuilder $container


### PR DESCRIPTION
I use the `PHPUnit\Framework\TestCase` notation instead of `PHPUnit_Framework_TestCase` while extending our TestCases. This will help us migrate to PHPUnit 6, that [no longer support snake case class names](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-6.0.md#changed-1).

PS: I won't apply [this](https://styleci.io/analyses/XVlgAg) `StyleCI` changes. There are not related to this PR :sweat_smile: 