### PR TITLE
Update CacheDataCollector.php

### DIFF
--- a/src/DataCollector/CacheDataCollector.php
+++ b/src/DataCollector/CacheDataCollector.php
@@ -70,7 +70,7 @@ class CacheDataCollector extends DataCollector
     }
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public function reset()
     {

--- a/src/DataCollector/CacheDataCollector.php
+++ b/src/DataCollector/CacheDataCollector.php
@@ -70,6 +70,15 @@ class CacheDataCollector extends DataCollector
     }
 
     /**
+     * @inheritdoc
+     */
+    public function reset()
+    {
+        $empty      = ['calls' => [], 'config' => [], 'options' => [], 'statistics' => []];
+        $this->data = ['instances' => $empty, 'total' => $empty];
+    }
+
+    /**
      * To be compatible with many versions of Symfony.
      *
      * @param $var


### PR DESCRIPTION
add reset method, which implement Symfony\Component\HttpKernel\DataCollector\DataCollectorInterface and solve deprication

> User Deprecated: Implementing "Symfony\Component\HttpKernel\DataCollector\DataCollectorInterface" without the "reset()" method is deprecated since Symfony 3.4 and will be unsupported in 4.0 for class "Cache\CacheBundle\DataCollector\CacheDataCollector".